### PR TITLE
sftpserver: Fix handling realloc failure

### DIFF
--- a/src/sftpserver.c
+++ b/src/sftpserver.c
@@ -668,14 +668,15 @@ ssh_string sftp_handle_alloc(sftp_session sftp, void *info)
   }
 
   if (i == sftp->total_allocated_handles) {
+    void **tmp;
     uint32_t old_size = sftp->total_allocated_handles;
-    sftp->total_allocated_handles += SFTP_HANDLES_CHUNK_SZ;
 
-    void **tmp = realloc(sftp->handles, sftp->total_allocated_handles * sizeof(void *));
+    tmp = realloc(sftp->handles, (old_size + SFTP_HANDLES_CHUNK_SZ) * sizeof(void *));
     if (tmp == NULL)
         return NULL; /* no handle available */
 
     sftp->handles = tmp;
+    sftp->total_allocated_handles += SFTP_HANDLES_CHUNK_SZ;
     memset(sftp->handles + old_size, '\0', SFTP_HANDLES_CHUNK_SZ * sizeof(void *));
   }
 


### PR DESCRIPTION
Previously one of our patches introduced a potential OOB error in the case that realloc fails. Now the OOB error will not occur if realloc fails. Also complies with C90 since that was preventing compilation which
fixes #7 

